### PR TITLE
Allow a prefix to be set

### DIFF
--- a/src/main/java/com/librato/metrics/LibratoUtil.java
+++ b/src/main/java/com/librato/metrics/LibratoUtil.java
@@ -14,6 +14,13 @@ public class LibratoUtil {
         // do not instantiate; static utility class
     }
 
+    public static String checkPrefix(String prefix) {
+        if ("".equals(prefix)) {
+            throw new IllegalArgumentException("Prefix may either be null or a non-empty string");
+        }
+        return prefix;
+    }
+
     /**
      * turn a MetricName into a Librato-able string key
      */


### PR DESCRIPTION
- all metrics reported will have the prefix prepended to the metric name
