### PR TITLE
Added dropwizard integration for config file support

### DIFF
--- a/dropwizard-metrics-librato/README.md
+++ b/dropwizard-metrics-librato/README.md
@@ -1,0 +1,29 @@
+Librato Reporter
+----------------
+
+Reports metrics periodically to the console.
+
+Extends the attributes that are available to :ref:`formatted reporters <man-configuration-metrics-formatted>`
+
+.. code-block:: yaml
+
+    metrics:
+      reporters:
+        - type: librato
+          username:
+          token:
+          source:
+          timeout:
+          prefix:
+          name:
+
+====================== ===============  ===========
+Name                   Default          Description
+====================== ===============  ===========
+username                                           
+token                                              
+source                                             
+timeout                                            
+prefix                                             
+name                                               
+====================== ===============  ===========

--- a/dropwizard-metrics-librato/pom.xml
+++ b/dropwizard-metrics-librato/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.sonatype.oss</groupId>
+    <artifactId>oss-parent</artifactId>
+    <version>7</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.librato.metrics</groupId>
+  <artifactId>dropwizard-metrics-librato</artifactId>
+  <name>Dropwizard Metrics Support for Librato</name>
+  <version>4.0.1.2-SNAPSHOT</version>
+  <description>
+    A reporter for Metrics which announces measurements to Librato.
+  </description>
+
+  <properties>
+    <codahale.metrics.version>3.0.1</codahale.metrics.version>
+    <dropwizard.metrics.version>0.7.0</dropwizard.metrics.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.dropwizard</groupId>
+      <artifactId>dropwizard-metrics</artifactId>
+      <version>${dropwizard.metrics.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.codahale.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <version>${codahale.metrics.version}</version>
+      <type>jar</type>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.librato.metrics</groupId>
+      <artifactId>metrics-librato</artifactId>
+      <version>4.0.1.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.easytesting</groupId>
+      <artifactId>fest-assert-core</artifactId>
+      <version>2.0M10</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/dropwizard-metrics-librato/src/main/java/io/dropwizard/metrics/LibratoReporterFactory.java
+++ b/dropwizard-metrics-librato/src/main/java/io/dropwizard/metrics/LibratoReporterFactory.java
@@ -1,0 +1,45 @@
+package io.dropwizard.metrics;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.ScheduledReporter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.librato.metrics.LibratoReporter;
+
+import javax.validation.constraints.NotNull;
+import java.util.concurrent.TimeUnit;
+
+@JsonTypeName("librato")
+public class LibratoReporterFactory extends BaseReporterFactory {
+    @NotNull
+    @JsonProperty
+    private String username = null;
+
+    @NotNull
+    @JsonProperty
+    private String token = null;
+
+    @NotNull
+    @JsonProperty
+    private String source = null;
+
+    @JsonProperty
+    private long timeout = 30000;
+
+    @JsonProperty
+    private String prefix = null;
+
+    @JsonProperty
+    private String name = null;
+
+    public ScheduledReporter build(MetricRegistry registry) {
+        return LibratoReporter.builder(registry, username, token, source)
+                .setTimeout(timeout, TimeUnit.MILLISECONDS)
+                .setPrefix(prefix)
+                .setRateUnit(getRateUnit())
+                .setDurationUnit(getDurationUnit())
+                .setName(name)
+                .setFilter(getFilter())
+                .build();
+    }
+}

--- a/dropwizard-metrics-librato/src/main/resources/META-INF/services/io.dropwizard.metrics.ReporterFactory
+++ b/dropwizard-metrics-librato/src/main/resources/META-INF/services/io.dropwizard.metrics.ReporterFactory
@@ -1,0 +1,1 @@
+io.dropwizard.metrics.LibratoReporterFactory

--- a/dropwizard-metrics-librato/src/test/java/io/dropwizard/metrics/LibratoReporterFactoryTest.java
+++ b/dropwizard-metrics-librato/src/test/java/io/dropwizard/metrics/LibratoReporterFactoryTest.java
@@ -1,0 +1,14 @@
+package io.dropwizard.metrics;
+
+import io.dropwizard.jackson.DiscoverableSubtypeResolver;
+import org.fest.assertions.api.Assertions;
+import org.junit.Test;
+
+public class LibratoReporterFactoryTest {
+    @Test
+    public void isDiscoverable() throws Exception {
+        Assertions.assertThat(new DiscoverableSubtypeResolver()
+                .getDiscoveredSubtypes())
+                .contains(LibratoReporterFactory.class);
+    }
+}


### PR DESCRIPTION
Added dropwizard integration for metrics-librato to automatically add LibratoReporter via a dropwizard configuration file from dropwizard 0.7.0. You can see an example at https://github.com/dropwizard/dropwizard/blob/v0.7.0/docs/source/manual/configuration.rst#graphite-reporter

I added this functionality as a separate maven project. I wasn't sure if @librato wanted to add this functionality as a separate module in `metrics-librato`.
