### PR TITLE
Add a catch exception to avoid the stopping of Scheduled task

### DIFF
--- a/src/main/java/com/librato/metrics/LibratoReporter.java
+++ b/src/main/java/com/librato/metrics/LibratoReporter.java
@@ -105,6 +105,15 @@ public class LibratoReporter extends ScheduledReporter implements MetricsLibrato
     }
 
     @Override
+    public void report() {
+        try {
+            super.report();
+        } catch (Exception exception) {
+            LOG.error("Error sending report to librato", exception);
+        }
+    }
+
+    @Override
     public void report(SortedMap<String, Gauge> gauges,
                        SortedMap<String, Counter> counters,
                        SortedMap<String, Histogram> histograms,


### PR DESCRIPTION
Without this catch, in case of a bug in application metrics, the scheduled task will be stopped.
