### PR TITLE
Omit complex gauges, optionally

### DIFF
--- a/src/main/java/com/librato/metrics/LibratoReporter.java
+++ b/src/main/java/com/librato/metrics/LibratoReporter.java
@@ -448,7 +448,8 @@ public class LibratoReporter extends ScheduledReporter implements MetricsLibrato
                     prefix,
                     prefixDelimiter,
                     sourceRegex,
-                    deleteIdleStats);
+                    deleteIdleStats,
+                    omitComplexGauges);
         }
 
         /**

--- a/src/main/java/com/librato/metrics/LibratoReporter.java
+++ b/src/main/java/com/librato/metrics/LibratoReporter.java
@@ -201,12 +201,24 @@ public class LibratoReporter extends ScheduledReporter implements MetricsLibrato
         private Pattern sourceRegex;
         private AsyncHttpClientConfig httpClientConfig;
         private boolean deleteIdleStats = true;
+        private boolean omitComplexGauges;
 
         public Builder(MetricRegistry registry, String username, String token, String source) {
             this.registry = registry;
             this.username = username;
             this.token = token;
             this.source = source;
+        }
+
+        /**
+         * Sets whether or not complex gauges (includes mean, min, max) should be sent to Librato. Only
+         * applies to Timers and Histograms.
+         * @param omitComplexGauges if the complex gauges should be elided
+         * @return itself
+         */
+        public Builder setOmitComplexGauges(boolean omitComplexGauges) {
+            this.omitComplexGauges = omitComplexGauges;
+            return this;
         }
 
         /**

--- a/src/main/java/com/librato/metrics/LibratoReporter.java
+++ b/src/main/java/com/librato/metrics/LibratoReporter.java
@@ -137,7 +137,8 @@ public class LibratoReporter extends ScheduledReporter implements MetricsLibrato
                 deltaTracker,
                 this,
                 this,
-                sourceRegex);
+                sourceRegex,
+                omitComplexGauges);
 
         for (Map.Entry<String, Gauge> entry : gauges.entrySet()) {
             batch.addGauge(entry.getKey(), entry.getValue());

--- a/src/main/java/com/librato/metrics/LibratoReporter.java
+++ b/src/main/java/com/librato/metrics/LibratoReporter.java
@@ -25,6 +25,7 @@ public class LibratoReporter extends ScheduledReporter implements MetricsLibrato
     private final String prefixDelimiter;
     private final Pattern sourceRegex;
     private final boolean deleteIdleStats;
+    private final boolean omitComplexGauges;
     protected final MetricRegistry registry;
     protected final Clock clock;
     protected final MetricExpansionConfig expansionConfig;
@@ -47,7 +48,8 @@ public class LibratoReporter extends ScheduledReporter implements MetricsLibrato
                             String prefix,
                             String prefixDelimiter,
                             Pattern sourceRegex,
-                            boolean deleteIdleStats) {
+                            boolean deleteIdleStats,
+                            boolean omitComplexGauges) {
         super(registry, name, filter, rateUnit, durationUnit);
         this.registry = registry;
         this.sanitizer = customSanitizer;
@@ -62,6 +64,7 @@ public class LibratoReporter extends ScheduledReporter implements MetricsLibrato
         this.sourceRegex = sourceRegex;
         this.deltaTracker = new DeltaTracker(new DeltaMetricSupplier(registry));
         this.deleteIdleStats = deleteIdleStats;
+        this.omitComplexGauges = omitComplexGauges;
     }
 
     public double convertMetricDuration(double duration) {


### PR DESCRIPTION
This PR exposes a new configuration option for the reporter, `omitComplexGauges`.  If set, metrics-librato will not report complex gauges for Timers and Histograms.  This is useful if you only want, for example, percentiles and are not interested in the mean, minimum, or maximum (those three dimensions are reported for the complex gauges).

By default, this is turned off, so existing configurations will continue to operate normally.