### PR TITLE
Close `HttpPoster` on `LibratoReporter` stop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>com.librato.metrics</groupId>
             <artifactId>librato-java</artifactId>
-            <version>1.0.8</version>
+            <version>1.0.9</version>
             <type>jar</type>
         </dependency>
         <dependency>

--- a/src/main/java/com/librato/metrics/LibratoReporter.java
+++ b/src/main/java/com/librato/metrics/LibratoReporter.java
@@ -6,6 +6,7 @@ import com.ning.http.client.AsyncHttpClientConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
@@ -107,6 +108,17 @@ public class LibratoReporter extends ScheduledReporter implements MetricsLibrato
     public void start(long period, TimeUnit unit) {
         LOG.debug("Reporter starting at fixed rate of every {} {}", period, unit);
         super.start(period, unit);
+    }
+
+    @Override
+    public void stop() {
+      // Stop the scheduling of tasks before stoping the http client the tasks use
+      super.stop();
+      try {
+        httpPoster.close();
+      } catch (IOException e) {
+        // Intentional NOP
+      }
     }
 
     @Override

--- a/src/main/java/com/librato/metrics/LibratoReporter.java
+++ b/src/main/java/com/librato/metrics/LibratoReporter.java
@@ -112,7 +112,8 @@ public class LibratoReporter extends ScheduledReporter implements MetricsLibrato
 
     @Override
     public void stop() {
-      // Stop the scheduling of tasks before stoping the http client the tasks use
+      // Stop the scheduling of tasks before stopping the http client which the
+      // tasks use
       super.stop();
       try {
         httpPoster.close();

--- a/src/test/java/com/librato/metrics/LibratoReporterTest.java
+++ b/src/test/java/com/librato/metrics/LibratoReporterTest.java
@@ -30,6 +30,10 @@ public class LibratoReporterTest extends TestCase {
             public Future<Response> post(String userAgent, String payload) throws IOException {
                 return null;
             }
+
+            public void close() throws IOException {
+              // Intentional NOP
+            }
         };
         LibratoReporter reporter = LibratoReporter.builder(registry, "test-username", "test-token", "test-source")
                 .setHttpPoster(poster)


### PR DESCRIPTION
Builds on top of https://github.com/librato/librato-java/pull/24

The `// Intentional NOP` comments are included since I've used some IDEs which issue warnings about empty blocks but I know some people view it as clutter.  I can remove those if that's the preference in this case.