### PR TITLE
Fix issue where a reset meter count would error out the delta tracker

### DIFF
--- a/src/main/java/com/librato/metrics/DeltaTracker.java
+++ b/src/main/java/com/librato/metrics/DeltaTracker.java
@@ -48,9 +48,6 @@ public class DeltaTracker {
      */
     public Long peekDelta(String name, long count) {
         Long previous = lookup.get(name);
-        if (previous == null) {
-            previous = 0L;
-        }
         return calculateDelta(name, previous, count);
     }
 
@@ -64,17 +61,15 @@ public class DeltaTracker {
      */
     public Long getDelta(String name, long count) {
         Long previous = lookup.put(name, count);
-        if (previous == null) {
-            // this is the first time we have seen this count
-            previous = 0L;
-        }
         return calculateDelta(name, previous, count);
     }
 
     private Long calculateDelta(String name, Long previous, long count) {
-        if (count < previous) {
-            LOG.error("Saw a non-monotonically increasing value for metric {}", name);
-            return 0L;
+        if (previous == null) {
+            previous = 0L;
+        } else if (count < previous) {
+            LOG.debug("Saw a non-monotonically increasing value for metric {}", name);
+            previous = 0L;
         }
         return count - previous;
     }

--- a/src/test/java/com/librato/metrics/DeltaTrackerTest.java
+++ b/src/test/java/com/librato/metrics/DeltaTrackerTest.java
@@ -39,6 +39,8 @@ public class DeltaTrackerTest {
         assertThat(converter.getDelta("foo", 1), is(1L));
         assertThat(converter.getDelta("foo", 0), is(0L));
         assertThat(converter.getDelta("foo", 5), equalTo(5L));
+        assertThat(converter.getDelta("foo", 2), equalTo(2L));
+        assertThat(converter.getDelta("foo", 5), equalTo(3L));
     }
 
     @Test
@@ -52,6 +54,7 @@ public class DeltaTrackerTest {
     @Test
     public void testPeekWorks() throws Exception {
         converter.getDelta("foo", 1); // sets the value of 1 for the metric count
+
         assertThat(converter.peekDelta("foo", 1), equalTo(0L));
         assertThat(converter.peekDelta("foo", 1), equalTo(0L));
         assertThat(converter.peekDelta("foo", 2), equalTo(1L));
@@ -64,5 +67,9 @@ public class DeltaTrackerTest {
         assertThat(converter.peekDelta("foo", 2), equalTo(0L));
         assertThat(converter.peekDelta("foo", 3), equalTo(1L));
         assertThat(converter.peekDelta("foo", 3), equalTo(1L));
+
+        // test an update that is less than the original (2)
+        assertThat(converter.peekDelta("foo", 1), equalTo(1L));
+        assertThat(converter.peekDelta("foo", 1), equalTo(1L));
     }
 }


### PR DESCRIPTION
The `peekDelta` method, because it always returned zero if the count was < previous, would continually log error messages because it wouldn't update the internal state. In this case, it will not skip the case where count < previous, but instead allow it, and it will eventually update the internal state when the actual metric is reported.