### PR TITLE
On demand tagging support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>com.librato.metrics</groupId>
             <artifactId>librato-java</artifactId>
-            <version>2.0.3-SNAPSHOT</version>
+            <version>2.0.3</version>
             <type>jar</type>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>com.librato.metrics</groupId>
             <artifactId>librato-java</artifactId>
-            <version>2.0.2</version>
+            <version>2.0.3-SNAPSHOT</version>
             <type>jar</type>
         </dependency>
         <dependency>

--- a/src/main/java/com/librato/metrics/reporter/DeltaTracker.java
+++ b/src/main/java/com/librato/metrics/reporter/DeltaTracker.java
@@ -18,7 +18,7 @@ public class DeltaTracker {
     private static final Logger LOG = LoggerFactory.getLogger(DeltaTracker.class);
     private final ConcurrentMap<String, Long> lookup = new ConcurrentHashMap<String, Long>();
 
-    public static interface MetricSupplier {
+    public interface MetricSupplier {
         Map<String, Metric> getMetrics();
     }
 

--- a/src/main/java/com/librato/metrics/reporter/Json.java
+++ b/src/main/java/com/librato/metrics/reporter/Json.java
@@ -1,0 +1,26 @@
+package com.librato.metrics.reporter;
+
+import org.codehaus.jackson.map.ObjectMapper;
+
+import java.io.IOException;
+
+public class Json {
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    public static String serialize(Object object) {
+        try {
+            return mapper.writeValueAsString(object);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static <T> T decode(String json, Class<T> klazz) {
+        try {
+            return mapper.readValue(json, klazz);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/main/java/com/librato/metrics/reporter/LRU.java
+++ b/src/main/java/com/librato/metrics/reporter/LRU.java
@@ -1,0 +1,26 @@
+package com.librato.metrics.reporter;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class LRU<K, V> {
+    private final Map<K,V> cache;
+
+    public LRU(final int maxSize) {
+        this.cache = Collections.synchronizedMap(new LinkedHashMap<K, V>() {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+                return size() > maxSize;
+            }
+        });
+    }
+
+    public V get(K key) {
+        return cache.get(key);
+    }
+
+    public void set(K key, V result) {
+        cache.put(key, result);
+    }
+}

--- a/src/main/java/com/librato/metrics/reporter/Librato.java
+++ b/src/main/java/com/librato/metrics/reporter/Librato.java
@@ -103,36 +103,64 @@ public class Librato {
     }
 
     public Counter counter() {
+        return counter(null);
+    }
+
+    public Counter counter(final Counter counter) {
         return register(Counter.class, new Supplier<Counter>() {
             @Override
             public Counter get() {
+                if (counter != null) {
+                    return counter;
+                }
                 return new Counter();
             }
         });
     }
 
     public Histogram histogram() {
+        return histogram(null);
+    }
+
+    public Histogram histogram(final Histogram histogram) {
         return register(Histogram.class, new Supplier<Histogram>() {
             @Override
             public Histogram get() {
+                if (histogram != null) {
+                    return histogram;
+                }
                 return new Histogram(reservoir.get());
             }
         });
     }
 
     public Meter meter() {
+        return meter(null);
+    }
+
+    public Meter meter(final Meter meter) {
         return register(Meter.class, new Supplier<Meter>() {
             @Override
             public Meter get() {
+                if (meter != null) {
+                    return meter;
+                }
                 return new Meter();
             }
         });
     }
 
     public Timer timer() {
+        return timer(null);
+    }
+
+    public Timer timer(final Timer timer) {
         return register(Timer.class, new Supplier<Timer>() {
             @Override
             public Timer get() {
+                if (timer != null) {
+                    return timer;
+                }
                 return new Timer(reservoir.get());
             }
         });

--- a/src/main/java/com/librato/metrics/reporter/Librato.java
+++ b/src/main/java/com/librato/metrics/reporter/Librato.java
@@ -1,0 +1,201 @@
+package com.librato.metrics.reporter;
+
+import com.codahale.metrics.*;
+import com.librato.metrics.client.Tag;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Utility class for encoding sources and/or tags into metric names.
+ */
+public class Librato {
+    private static Supplier<Reservoir> defaultReservoir = new Supplier<Reservoir>() {
+        @Override
+        public Reservoir get() {
+            return new ExponentiallyDecayingReservoir();
+        }
+    };
+    private static final NameCache nameCache = new NameCache(5000);
+    private final MetricRegistry registry;
+    private final String name;
+    private String source;
+    private List<Tag> tags = Collections.emptyList();
+    private boolean overrideTags;
+    private Supplier<Reservoir> reservoir = defaultReservoir;
+
+    public static void defaultReservoir(Supplier<Reservoir> reservoir) {
+        defaultReservoir = reservoir;
+    }
+
+    public static Librato metric(String name) {
+        MetricRegistry registry = LibratoReporter.registry();
+        if (registry == null) {
+            throw new RuntimeException(
+                    "You must first start the LibratoReporter to use this method");
+        }
+        return metric(registry, name);
+    }
+
+    public static Librato metric(MetricRegistry registry, String name) {
+        return new Librato(registry, name);
+    }
+
+    public Librato(MetricRegistry registry, String name) {
+        this.registry = registry;
+        this.name = name;
+    }
+
+    public Librato reservoir(Supplier<Reservoir> reservoir) {
+        this.reservoir = reservoir;
+        return this;
+    }
+
+    public Librato window(final long window, final TimeUnit unit) {
+        this.reservoir = new Supplier<Reservoir>() {
+            @Override
+            public Reservoir get() {
+                return new SlidingTimeWindowReservoir(window, unit);
+            }
+        };
+        return this;
+    }
+
+    public Librato source(String source) {
+        this.source = source;
+        return this;
+    }
+
+    public Librato tag(String name, String value) {
+        addTag(new Tag(name, value));
+        return this;
+    }
+
+    public Librato tags(Tag... tags) {
+        for (Tag tag : tags) {
+            addTag(tag);
+        }
+        return this;
+    }
+
+    public Librato tags(List<Tag> tags) {
+        for (Tag tag : tags) {
+            addTag(tag);
+        }
+        return this;
+    }
+
+    public Librato inheritTags(boolean inheritTags) {
+        this.overrideTags = !inheritTags;
+        return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> Gauge<T> gauge(final Gauge<T> gauge) {
+        return register(Gauge.class, new Supplier<Gauge>() {
+            @Override
+            public Gauge get() {
+                return gauge;
+            }
+        });
+    }
+
+    public Counter counter() {
+        return register(Counter.class, new Supplier<Counter>() {
+            @Override
+            public Counter get() {
+                return new Counter();
+            }
+        });
+    }
+
+    public Histogram histogram() {
+        return register(Histogram.class, new Supplier<Histogram>() {
+            @Override
+            public Histogram get() {
+                return new Histogram(reservoir.get());
+            }
+        });
+    }
+
+    public Meter meter() {
+        return register(Meter.class, new Supplier<Meter>() {
+            @Override
+            public Meter get() {
+                return new Meter();
+            }
+        });
+    }
+
+    public Timer timer() {
+        return register(Timer.class, new Supplier<Timer>() {
+            @Override
+            public Timer get() {
+                return new Timer(reservoir.get());
+            }
+        });
+    }
+
+    private void addTag(Tag tag) {
+        if (this.tags.isEmpty()) {
+            this.tags = new LinkedList<Tag>();
+        }
+        this.tags.add(tag);
+    }
+
+    private <T extends Metric> T register(Class<T> klass, Supplier<T> metric) {
+        Signal signal = createSignal();
+        if (signal == null) {
+            return register(registry, name, metric, klass);
+        }
+        String encodedName = encodeName(name, signal);
+        return register(registry, encodedName, metric, klass);
+    }
+
+    private <T extends Metric> T register(MetricRegistry registry,
+                                          String name,
+                                          Supplier<T> metric,
+                                          Class<T> klass) {
+        Metric found = registry.getMetrics().get(name);
+        if (found != null) {
+            return verifyFound(found, klass);
+        }
+        try {
+            return registry.register(name, metric.get());
+        } catch (IllegalArgumentException e) {
+            found = registry.getMetrics().get(name);
+            if (found == null) {
+                throw e;
+            }
+            return verifyFound(found, klass);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends Metric> T verifyFound(Metric found, Class<T> klass) {
+        if (!klass.isAssignableFrom(found.getClass())) {
+            throw new RuntimeException("A metric with " + found.getClass() + " already exists for this name");
+        }
+        return (T)found;
+    }
+
+    private Signal createSignal() {
+        if (source == null && tags.isEmpty()) {
+            return null;
+        }
+        return new Signal(name, source, tags, overrideTags);
+    }
+
+    private String encodeName(final String name, final Signal signal) {
+        return nameCache.get(name, signal, new Supplier<String>() {
+            @Override
+            public String get() {
+                return Json.serialize(signal);
+            }
+        });
+    }
+
+
+}

--- a/src/main/java/com/librato/metrics/reporter/Librato.java
+++ b/src/main/java/com/librato/metrics/reporter/Librato.java
@@ -30,6 +30,9 @@ public class Librato {
     private boolean overrideTags;
     private Supplier<Reservoir> reservoir = defaultReservoir.get();
 
+    public static ReporterBuilder reporter(MetricRegistry registry, String email, String token) {
+        return new ReporterBuilder(registry, email, token);
+    }
 
     public static Librato metric(String name) {
         MetricRegistry registry = defaultRegistry.get();

--- a/src/main/java/com/librato/metrics/reporter/Librato.java
+++ b/src/main/java/com/librato/metrics/reporter/Librato.java
@@ -71,13 +71,13 @@ public class Librato {
         return this;
     }
 
-    public Librato source(String source) {
-        this.source = source;
+    public Librato source(Object source) {
+        this.source = source.toString();
         return this;
     }
 
-    public Librato tag(String name, String value) {
-        addTag(new Tag(name, value));
+    public Librato tag(String name, Object value) {
+        addTag(new Tag(name, value.toString()));
         return this;
     }
 

--- a/src/main/java/com/librato/metrics/reporter/Librato.java
+++ b/src/main/java/com/librato/metrics/reporter/Librato.java
@@ -189,7 +189,7 @@ public class Librato {
         if (signal == null) {
             return register(registry, name, metric, klass);
         }
-        String encodedName = encodeName(name, signal);
+        String encodedName = encodeName(signal);
         return register(registry, encodedName, metric, klass);
     }
 
@@ -228,8 +228,8 @@ public class Librato {
     }
 
 
-    private String encodeName(final String name, final Signal signal) {
-        return nameCache.get(name, signal, new Supplier<String>() {
+    private String encodeName(final Signal signal) {
+        return nameCache.get(signal, new Supplier<String>() {
             @Override
             public String get() {
                 return Json.serialize(signal);

--- a/src/main/java/com/librato/metrics/reporter/Librato.java
+++ b/src/main/java/com/librato/metrics/reporter/Librato.java
@@ -87,8 +87,8 @@ public class Librato {
         return this;
     }
 
-    public Librato inheritTags(boolean inheritTags) {
-        this.overrideTags = !inheritTags;
+    public Librato doNotInheritTags() {
+        this.overrideTags = true;
         return this;
     }
 

--- a/src/main/java/com/librato/metrics/reporter/NameCache.java
+++ b/src/main/java/com/librato/metrics/reporter/NameCache.java
@@ -1,0 +1,29 @@
+package com.librato.metrics.reporter;
+
+public class NameCache {
+    public static class Key {
+        final String name;
+        final Signal signal;
+
+        public Key(String name, Signal signal) {
+            this.name = name;
+            this.signal = signal;
+        }
+    }
+
+    private final LRU<Key, String> cache;
+
+    public NameCache(int maxSize) {
+        this.cache = new LRU<Key, String>(maxSize);
+    }
+
+    public String get(String name, Signal signal, Supplier<String> fullNameSupplier) {
+        Key key = new Key(name, signal);
+        String result = cache.get(key);
+        if (result == null) {
+            result = fullNameSupplier.get();
+            cache.set(key, result);
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/librato/metrics/reporter/NameCache.java
+++ b/src/main/java/com/librato/metrics/reporter/NameCache.java
@@ -1,28 +1,17 @@
 package com.librato.metrics.reporter;
 
 public class NameCache {
-    public static class Key {
-        final String name;
-        final Signal signal;
-
-        public Key(String name, Signal signal) {
-            this.name = name;
-            this.signal = signal;
-        }
-    }
-
-    private final LRU<Key, String> cache;
+    private final LRU<Signal, String> cache;
 
     public NameCache(int maxSize) {
-        this.cache = new LRU<Key, String>(maxSize);
+        this.cache = new LRU<Signal, String>(maxSize);
     }
 
-    public String get(String name, Signal signal, Supplier<String> fullNameSupplier) {
-        Key key = new Key(name, signal);
-        String result = cache.get(key);
+    public String get(Signal signal, Supplier<String> fullNameSupplier) {
+        String result = cache.get(signal);
         if (result == null) {
             result = fullNameSupplier.get();
-            cache.set(key, result);
+            cache.set(signal, result);
         }
         return result;
     }

--- a/src/main/java/com/librato/metrics/reporter/Signal.java
+++ b/src/main/java/com/librato/metrics/reporter/Signal.java
@@ -1,0 +1,80 @@
+package com.librato.metrics.reporter;
+
+import com.librato.metrics.client.Tag;
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+import java.util.Collections;
+import java.util.List;
+
+public class Signal {
+    public String name;
+    public String source;
+    public List<Tag> tags = Collections.emptyList();
+    public boolean overrideTags;
+
+    public static Signal decode(String data) {
+        if (data == null || data.length() < 2 || data.charAt(0) != '{') {
+            return new Signal(data);
+        }
+        return Json.decode(data, Signal.class);
+    }
+
+    public Signal(String name) {
+        this.name = name;
+    }
+
+    public Signal(String name, String source) {
+        this.name = name;
+        this.source = source;
+    }
+
+    @JsonCreator
+    public Signal(@JsonProperty("name") String name,
+                  @JsonProperty("source") String source,
+                  @JsonProperty("tags") List<Tag> tags,
+                  @JsonProperty("overrideTags") boolean overrideTags) {
+        this.name = name;
+        this.source = source;
+        if (tags != null) {
+            this.tags = tags;
+        }
+        this.overrideTags = overrideTags;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Signal signal = (Signal) o;
+
+        if (overrideTags != signal.overrideTags) return false;
+        if (name != null ? !name.equals(signal.name) : signal.name != null)
+            return false;
+        if (source != null ? !source.equals(signal.source) : signal.source != null)
+            return false;
+        return tags != null ? tags.equals(signal.tags) : signal.tags == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (source != null ? source.hashCode() : 0);
+        result = 31 * result + (tags != null ? tags.hashCode() : 0);
+        result = 31 * result + (overrideTags ? 1 : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("Signal{");
+        sb.append("name='").append(name).append('\'');
+        sb.append(", source='").append(source).append('\'');
+        sb.append(", tags=").append(tags);
+        sb.append(", overrideTags=").append(overrideTags);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/librato/metrics/reporter/Signal.java
+++ b/src/main/java/com/librato/metrics/reporter/Signal.java
@@ -42,7 +42,6 @@ public class Signal {
         this.overrideTags = overrideTags;
     }
 
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/com/librato/metrics/reporter/Supplier.java
+++ b/src/main/java/com/librato/metrics/reporter/Supplier.java
@@ -1,0 +1,5 @@
+package com.librato.metrics.reporter;
+
+public interface Supplier<T> {
+    T get();
+}

--- a/src/test/java/com/librato/metrics/reporter/LibratoTest.java
+++ b/src/test/java/com/librato/metrics/reporter/LibratoTest.java
@@ -1,0 +1,105 @@
+package com.librato.metrics.reporter;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+import com.librato.metrics.client.Tag;
+import org.junit.Test;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LibratoTest {
+    MetricRegistry registry = new MetricRegistry();
+
+    @Test(expected = RuntimeException.class)
+    public void testErrorsOnSameNameDifferentTypes() throws Exception {
+        Librato.metric(registry, "foo").timer();
+        Librato.metric(registry, "foo").histogram();
+    }
+
+    @Test
+    public void testReturnsSameMetric() throws Exception {
+        Gauge<Integer> gauge = new Gauge<Integer>() {
+            @Override
+            public Integer getValue() {
+                return 42;
+            }
+        };
+
+        assertThat(Librato.metric(registry, "gauge").gauge(gauge))
+                .isSameAs(Librato.metric(registry, "gauge").gauge(gauge));
+
+        assertThat(Librato.metric(registry, "foo").timer())
+                .isSameAs(Librato.metric(registry, "foo").timer());
+
+        assertThat(Librato.metric(registry, "bar").source("baz").tag("region", "us-east-1").histogram()).isSameAs(
+                Librato.metric(registry, "bar").source("baz").tag("region", "us-east-1").histogram());
+    }
+
+    @Test
+    public void testNoNameConversion() throws Exception {
+        Librato.metric(registry, "gauge").gauge(new Gauge<Integer>() {
+            @Override
+            public Integer getValue() {
+                return 42;
+            }
+        });
+        assertThat(Signal.decode(registry.getGauges().keySet().iterator().next())).isEqualTo(
+                new Signal("gauge"));
+
+        Librato.metric(registry, "counter").counter();
+        assertThat(Signal.decode(registry.getCounters().keySet().iterator().next())).isEqualTo(
+                new Signal("counter"));
+
+        Librato.metric(registry, "histogram").histogram();
+        assertThat(Signal.decode(registry.getHistograms().keySet().iterator().next())).isEqualTo(
+                new Signal("histogram"));
+
+        Librato.metric(registry, "meter").meter();
+        assertThat(Signal.decode(registry.getMeters().keySet().iterator().next())).isEqualTo(
+                new Signal("meter"));
+
+        Librato.metric(registry, "timer").timer();
+        assertThat(Signal.decode(registry.getTimers().keySet().iterator().next())).isEqualTo(
+                new Signal("timer"));
+    }
+
+    @Test
+    public void testSourceConversion() throws Exception {
+        Librato.metric(registry, "foo").source("test-source").counter();
+        Signal signal = Signal.decode(registry.getCounters().keySet().iterator().next());
+        assertThat(signal.name).isEqualTo("foo");
+        assertThat(signal.source).isEqualTo("test-source");
+        assertThat(signal.tags).isEmpty();
+        assertThat(signal.overrideTags).isFalse();
+    }
+
+    @Test
+    public void testTagsConversion() throws Exception {
+        Librato.metric(registry, "foo")
+                .tag("region", "us-east-1")
+                .inheritTags(false)
+                .counter();
+        Signal signal = Signal.decode(registry.getCounters().keySet().iterator().next());
+        assertThat(signal).isEqualTo(new Signal(
+                "foo",
+                null,
+                asList(new Tag("region", "us-east-1")),
+                true));
+    }
+
+    @Test
+    public void testSourceAndTagsConversion() throws Exception {
+        Librato.metric(registry, "foo")
+                .tag("region", "us-east-1")
+                .inheritTags(false)
+                .source("bar")
+                .counter();
+        Signal signal = Signal.decode(registry.getCounters().keySet().iterator().next());
+        assertThat(signal).isEqualTo(new Signal(
+                "foo",
+                "bar",
+                asList(new Tag("region", "us-east-1")),
+                true));
+    }
+}

--- a/src/test/java/com/librato/metrics/reporter/LibratoTest.java
+++ b/src/test/java/com/librato/metrics/reporter/LibratoTest.java
@@ -78,7 +78,7 @@ public class LibratoTest {
     public void testTagsConversion() throws Exception {
         Librato.metric(registry, "foo")
                 .tag("region", "us-east-1")
-                .inheritTags(false)
+                .doNotInheritTags()
                 .counter();
         Signal signal = Signal.decode(registry.getCounters().keySet().iterator().next());
         assertThat(signal).isEqualTo(new Signal(
@@ -92,7 +92,7 @@ public class LibratoTest {
     public void testSourceAndTagsConversion() throws Exception {
         Librato.metric(registry, "foo")
                 .tag("region", "us-east-1")
-                .inheritTags(false)
+                .doNotInheritTags()
                 .source("bar")
                 .counter();
         Signal signal = Signal.decode(registry.getCounters().keySet().iterator().next());

--- a/src/test/java/com/librato/metrics/reporter/NameCacheTest.java
+++ b/src/test/java/com/librato/metrics/reporter/NameCacheTest.java
@@ -1,0 +1,28 @@
+package com.librato.metrics.reporter;
+
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NameCacheTest {
+    @Test
+    public void testServesUpCachedVersion() throws Exception {
+        NameCache cache = new NameCache(10);
+
+        final AtomicInteger invocations = new AtomicInteger();
+        Supplier<String> supplier = new Supplier<String>() {
+            @Override
+            public String get() {
+                invocations.incrementAndGet();
+                return "value";
+            }
+        };
+        assertThat(cache.get(new Signal("foo", "bar"), supplier)).isEqualTo("value");
+        assertThat(invocations.get()).isEqualTo(1);
+        assertThat(cache.get(new Signal("foo", "bar"), supplier)).isEqualTo("value");
+        assertThat(invocations.get()).isEqualTo(1);
+
+    }
+}


### PR DESCRIPTION
This is an iteration over the previous major change to this library which gave it the ability to be initialized with a set of tags at startup.  Now, we receive the ability to add tags as needed in application code at the metric level.

To do this we've revamped how we encode metric names in the Metric Registry -- it is now a JSON-encoded data structure that details metric name, source, tags, and whether or not the tags should inherit the tags declared at startup when reporting that metric to Librato.

To hide this complexity from the end-user we have introduced a new fluent helper class named `Librato`.

Some examples:

```
Librato.metric(registry, "logins").tag("uid", uid).meter().mark()
Librato.metric(registry, "kafka-read-latencies").tag("broker", broker).histogram().update(latency)
Librato.metric(registry, "temperature").source("celcius").tag("type", "celcius").gauge(() -> 42))
Librato.metric(registry, "jobs-processed").source("ebs").meter().mark()
Librato.metric(registry, "out-of-ideas-for-metric-names").gauge(() -> 42)
Librato.metric(registry, "just-these-tags").tag('"foo", "bar").doNotInheritTags().timer.update(time)
```

Tagged measures will, by default, inherit base level tags, unless the user specifies `doNotInheritTags()` on the builder.

There is no problem with not using the fluent helper if the user does not wish to do so, as it is fully backward compatible with previous versions.  

There is no need to retain the metric instances that the helper class produces, as it will check whether or not that metric with the specified sources, tags, and so on already exists in the registry.  This should obviate our need for the Metrics type classes we have in almost every project to help out with source encoding.
