### PR TITLE
Fix tag inheritance

### DIFF
--- a/src/main/java/com/librato/metrics/reporter/LibratoReporter.java
+++ b/src/main/java/com/librato/metrics/reporter/LibratoReporter.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.SocketTimeoutException;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.SortedMap;
@@ -81,7 +82,7 @@ public class LibratoReporter extends ScheduledReporter implements RateConverter,
                        SortedMap<String, Meter> meters,
                        SortedMap<String, Timer> timers) {
         long epoch = System.currentTimeMillis() / 1000;
-        Measures measures = new Measures(source, tags, epoch, defaultPeriod);
+        Measures measures = new Measures(source, Collections.<Tag>emptyList(), epoch, defaultPeriod);
         addGauges(measures, gauges);
         addCounters(measures, counters);
         addHistograms(measures, histograms);

--- a/src/test/java/com/librato/metrics/reporter/LibratoReporterTest.java
+++ b/src/test/java/com/librato/metrics/reporter/LibratoReporterTest.java
@@ -66,7 +66,7 @@ public class LibratoReporterTest {
         HashSet<IMeasure> measures = new HashSet<IMeasure>(captured.getMeasures());
         assertThat(captured.getTags()).isEmpty();
         assertThat(measures).containsOnly(
-                new TaggedMeasure("foo", 1, new Tag("root", "tag"), new Tag("foo", "bar")));
+                new TaggedMeasure("foo", 1, new Tag("foo", "bar"), new Tag("root", "tag")));
     }
 
     @Test

--- a/src/test/java/com/librato/metrics/reporter/LibratoReporterTest.java
+++ b/src/test/java/com/librato/metrics/reporter/LibratoReporterTest.java
@@ -54,6 +54,22 @@ public class LibratoReporterTest {
     }
 
     @Test
+    public void testOmitsTagsAtTheRootLevel() throws Exception {
+        atts.enableLegacy = false;
+        atts.enableTagging = true;
+        atts.tags.add(new Tag("root", "tag"));
+
+        Librato.metric(registry, "foo").tag("foo", "bar").counter().inc();
+        LibratoReporter reporter = new LibratoReporter(atts);
+        report(reporter);
+        Measures captured = captor.getValue();
+        HashSet<IMeasure> measures = new HashSet<IMeasure>(captured.getMeasures());
+        assertThat(captured.getTags()).isEmpty();
+        assertThat(measures).containsOnly(
+                new TaggedMeasure("foo", 1, new Tag("root", "tag"), new Tag("foo", "bar")));
+    }
+
+    @Test
     public void testCounter() throws Exception {
         Counter counter = new Counter();
         registry.register("foo", counter);
@@ -69,12 +85,13 @@ public class LibratoReporterTest {
     public void testRejectsNonTaggedMetrics() throws Exception {
         atts.enableLegacy = false;
         atts.enableTagging = true;
-        Counter counter = Librato.metric(registry, "foo").counter();
-        counter.inc();
-        LibratoReporter reporter = new LibratoReporter(atts);
+        Librato.metric(registry, "foo").counter().inc();
+        LibratoReporter reporter;
+        reporter = new LibratoReporter(atts);
         report(reporter);
-        HashSet<IMeasure> measures = new HashSet<IMeasure>(captor.getValue().getMeasures());
-        assertThat(measures.isEmpty());
+        HashSet<IMeasure> measures;
+        measures = new HashSet<IMeasure>(captor.getValue().getMeasures());
+        assertThat(measures.isEmpty()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
The metrics-librato reporter will not not put common tags into the root level of the payload but include them with every measure. This will allow the `.doNotInheritTags()` directive to work properly.

cc @lucky 