### PR TITLE
Updating librato-java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>com.librato.metrics</groupId>
             <artifactId>librato-java</artifactId>
-            <version>2.1.0</version>
+            <version>2.1.2</version>
             <type>jar</type>
         </dependency>
         <dependency>

--- a/src/main/java/com/librato/metrics/reporter/LibratoReporter.java
+++ b/src/main/java/com/librato/metrics/reporter/LibratoReporter.java
@@ -341,6 +341,8 @@ public class LibratoReporter extends ScheduledReporter implements RateConverter,
         return super.convertDuration(duration);
     }
 
+    // TODO: It's not clear to me that this even needs to be called, here, since librato-java
+    // already does the dirty work of sanitizing inputs -jr, 12/21/17
     private List<Tag> sanitize(List<Tag> tags) {
         List<Tag> result = new LinkedList<Tag>();
         for (Tag tag : tags) {

--- a/src/main/java/com/librato/metrics/reporter/LibratoReporter.java
+++ b/src/main/java/com/librato/metrics/reporter/LibratoReporter.java
@@ -1,7 +1,25 @@
 package com.librato.metrics.reporter;
 
-import com.codahale.metrics.*;
-import com.librato.metrics.client.*;
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Counting;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Metered;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Sampling;
+import com.codahale.metrics.ScheduledReporter;
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.Timer;
+import com.librato.metrics.client.Duration;
+import com.librato.metrics.client.GaugeMeasure;
+import com.librato.metrics.client.LibratoClient;
+import com.librato.metrics.client.Measures;
+import com.librato.metrics.client.PostMeasuresResult;
+import com.librato.metrics.client.PostResult;
+import com.librato.metrics.client.Sanitizer;
+import com.librato.metrics.client.Tag;
+import com.librato.metrics.client.TaggedMeasure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -332,7 +350,7 @@ public class LibratoReporter extends ScheduledReporter implements RateConverter,
     }
 
     private Tag sanitize(Tag tag) {
-        return new Tag(Sanitizer.LAST_PASS.apply(tag.name), Sanitizer.LAST_PASS.apply(tag.value));
+        return new Tag(Sanitizer.TAG_NAME_SANITIZER.apply(tag.name), Sanitizer.TAG_VALUE_SANITIZER.apply(tag.value));
     }
 
 }


### PR DESCRIPTION
* Moving `librato-java` to 2.1.2
* Using the updated calls to sanitize tag inputs

It's not clear to me that we even _need_ to have sanitizing done in this package since `librato-java` already does that. Still, going with the minimum change, here.